### PR TITLE
Uses templates for GitRepo paths.

### DIFF
--- a/tests/values/gitRepoValues.yml
+++ b/tests/values/gitRepoValues.yml
@@ -1,0 +1,29 @@
+GitHub:
+  Org_test_Automation:
+    path: jfbetapipeorg/Org_test_Automation
+  Org_test_Automation_bash:
+    path: jfbetapipeorg/Org_test_Automation_bash
+  Org_test_Automation_PowerShell:
+    path: jfbetapipeorg/Org_test_Automation_PowerShell
+
+GitHubEnterprise:
+  Org_test_Automation:
+    path: jfbetapipeorg/Org_test_Automation
+  test_automation:
+    path: jfbeta/test_automation
+
+GitLab:
+  test_automation:
+    path: jfbeta/test_automation
+
+BitbucketCloud:
+  jfrogtesting:
+    path: jfbeta/jfrogtesting
+  test_automation:
+    path: jfbeta/test_automation
+
+BitbucketServer:
+  automation:
+    path: PIP/automation
+  test_automation:
+    path: PIP/test_automation

--- a/tests/yaml/S_PS_R_GIT_0001.yml
+++ b/tests/yaml/S_PS_R_GIT_0001.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0001_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipelines_S_PS_R_GIT_0001

--- a/tests/yaml/S_PS_R_GIT_0002.yml
+++ b/tests/yaml/S_PS_R_GIT_0002.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0002_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_bitbucket
-      path: jfbeta/jfrogtesting
+      path: {{ .Values.BitbucketCloud.jfrogtesting.path }}
 
 pipelines:
   - name: pipelines_S_PS_R_GIT_0002

--- a/tests/yaml/S_PS_R_GIT_0003.yml
+++ b/tests/yaml/S_PS_R_GIT_0003.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0003_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_bitbucketServer
-      path: PIP/automation
+      path: {{ .Values.BitbucketServer.automation.path }}
 
 pipelines:
   - name: pipelines_S_PS_R_GIT_0003

--- a/tests/yaml/S_PS_R_GIT_0004.yml
+++ b/tests/yaml/S_PS_R_GIT_0004.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0004_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_gitlab
-      path: jfbeta/test_automation
+      path: {{ .Values.GitLab.test_automation.path }}
 
 pipelines:
   - name: pipelines_S_PS_R_GIT_0004

--- a/tests/yaml/S_PS_R_GIT_0005.yml
+++ b/tests/yaml/S_PS_R_GIT_0005.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0005_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_githubEnterprise
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHubEnterprise.Org_test_Automation.path }}
 
 pipelines:
   - name: pipelines_S_PS_R_GIT_0005

--- a/tests/yaml/S_PS_R_GIT_0006.yml
+++ b/tests/yaml/S_PS_R_GIT_0006.yml
@@ -1,12 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0006_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
-      branches:
-        include: master
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipelines_S_PS_R_GIT_0006

--- a/tests/yaml/S_PS_R_GIT_0007.yml
+++ b/tests/yaml/S_PS_R_GIT_0007.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0007_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_bitbucket
-      path: jfbeta/jfrogtesting
+      path: {{ .Values.BitbucketCloud.jfrogtesting.path }}
       branches:
         include: master
       buildOn:  # optional

--- a/tests/yaml/S_PS_R_GIT_0008.yml
+++ b/tests/yaml/S_PS_R_GIT_0008.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0008_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_bitbucketServer
-      path: PIP/automation
+      path: {{ .Values.BitbucketServer.automation.path }}
       branches:
         include: master
       buildOn:  # optional

--- a/tests/yaml/S_PS_R_GIT_0009.yml
+++ b/tests/yaml/S_PS_R_GIT_0009.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0009_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_gitlab
-      path: jfbeta/test_automation
+      path: {{ .Values.GitLab.test_automation.path }}
       branches:
         include: master
       buildOn:  # optional

--- a/tests/yaml/S_PS_R_GIT_0010.yml
+++ b/tests/yaml/S_PS_R_GIT_0010.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0010_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_githubEnterprise
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHubEnterprise.Org_test_Automation.path }}
       branches:
         include: master
       buildOn:  # optional

--- a/tests/yaml/S_PS_R_GIT_0011.yml
+++ b/tests/yaml/S_PS_R_GIT_0011.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0011_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
       branches:
         include: master
 

--- a/tests/yaml/S_PS_R_GIT_0012.yml
+++ b/tests/yaml/S_PS_R_GIT_0012.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0012_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_bitbucket
-      path: jfbeta/jfrogtesting
+      path: {{ .Values.BitbucketCloud.jfrogtesting.path }}
       branches:
         include: master
       buildOn:  # optional

--- a/tests/yaml/S_PS_R_GIT_0013.yml
+++ b/tests/yaml/S_PS_R_GIT_0013.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0013_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_bitbucketServer
-      path: PIP/automation
+      path: {{ .Values.BitbucketServer.automation.path }}
       branches:
         include: master
       buildOn:  # optional

--- a/tests/yaml/S_PS_R_GIT_0014.yml
+++ b/tests/yaml/S_PS_R_GIT_0014.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0014_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_gitlab
-      path: jfbeta/test_automation
+      path: {{ .Values.GitLab.test_automation.path }}
       branches:
         include: master
       buildOn:  # optional

--- a/tests/yaml/S_PS_R_GIT_0015.yml
+++ b/tests/yaml/S_PS_R_GIT_0015.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0015_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_githubEnterprise
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHubEnterprise.Org_test_Automation.path }}
       branches:
         include: master
       buildOn:  # optional

--- a/tests/yaml/S_PS_R_GIT_0016.yml
+++ b/tests/yaml/S_PS_R_GIT_0016.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0016_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipelines_S_PS_R_GIT_0016

--- a/tests/yaml/S_PS_R_GIT_0017.yml
+++ b/tests/yaml/S_PS_R_GIT_0017.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0017_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_bitbucket
-      path: jfbeta/jfrogtesting
+      path: {{ .Values.BitbucketCloud.jfrogtesting.path }}
 
 pipelines:
   - name: pipelines_S_PS_R_GIT_0017

--- a/tests/yaml/S_PS_R_GIT_0018.yml
+++ b/tests/yaml/S_PS_R_GIT_0018.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0018_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_bitbucketServer
-      path: PIP/automation
+      path: {{ .Values.BitbucketServer.automation.path }}
 
 pipelines:
   - name: pipelines_S_PS_R_GIT_0018

--- a/tests/yaml/S_PS_R_GIT_0019.yml
+++ b/tests/yaml/S_PS_R_GIT_0019.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0019_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_gitlab
-      path: jfbeta/test_automation
+      path: {{ .Values.GitLab.test_automation.path }}
 
 pipelines:
   - name: pipelines_S_PS_R_GIT_0019

--- a/tests/yaml/S_PS_R_GIT_0020.yml
+++ b/tests/yaml/S_PS_R_GIT_0020.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0020_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_githubEnterprise
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHubEnterprise.Org_test_Automation.path }}
 
 pipelines:
   - name: pipelines_S_PS_R_GIT_0020

--- a/tests/yaml/S_PS_R_GIT_0021.yml
+++ b/tests/yaml/S_PS_R_GIT_0021.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0021_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipelines_S_PS_R_GIT_0021

--- a/tests/yaml/S_PS_R_GIT_0022.yml
+++ b/tests/yaml/S_PS_R_GIT_0022.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0022_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_bitbucket
-      path: jfbeta/jfrogtesting
+      path: {{ .Values.BitbucketCloud.jfrogtesting.path }}
 
 pipelines:
   - name: pipelines_S_PS_R_GIT_0022

--- a/tests/yaml/S_PS_R_GIT_0023.yml
+++ b/tests/yaml/S_PS_R_GIT_0023.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0023_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_bitbucketServer
-      path: PIP/automation
+      path: {{ .Values.BitbucketServer.automation.path }}
 
 pipelines:
   - name: pipelines_S_PS_R_GIT_0023

--- a/tests/yaml/S_PS_R_GIT_0024.yml
+++ b/tests/yaml/S_PS_R_GIT_0024.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0024_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_gitlab
-      path: jfbeta/test_automation
+      path: {{ .Values.GitLab.test_automation.path }}
 
 pipelines:
   - name: pipelines_S_PS_R_GIT_0024

--- a/tests/yaml/S_PS_R_GIT_0025.yml
+++ b/tests/yaml/S_PS_R_GIT_0025.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0025_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_githubEnterprise
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHubEnterprise.Org_test_Automation.path }}
 
 pipelines:
   - name: pipelines_S_PS_R_GIT_0025

--- a/tests/yaml/S_PS_R_GIT_0026.yml
+++ b/tests/yaml/S_PS_R_GIT_0026.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0026_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipelines_S_PS_R_GIT_0026

--- a/tests/yaml/S_PS_R_GIT_0027.yml
+++ b/tests/yaml/S_PS_R_GIT_0027.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0027_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_bitbucket
-      path: jfbeta/jfrogtesting
+      path: {{ .Values.BitbucketCloud.jfrogtesting.path }}
 
 pipelines:
   - name: pipelines_S_PS_R_GIT_0027

--- a/tests/yaml/S_PS_R_GIT_0028.yml
+++ b/tests/yaml/S_PS_R_GIT_0028.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0028_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_bitbucketServer
-      path: PIP/automation
+      path: {{ .Values.BitbucketServer.automation.path }}
 
 pipelines:
   - name: pipelines_S_PS_R_GIT_0028

--- a/tests/yaml/S_PS_R_GIT_0029.yml
+++ b/tests/yaml/S_PS_R_GIT_0029.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0029_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_gitlab
-      path: jfbeta/test_automation
+      path: {{ .Values.GitLab.test_automation.path }}
 
 pipelines:
   - name: pipelines_S_PS_R_GIT_0029

--- a/tests/yaml/S_PS_R_GIT_0030.yml
+++ b/tests/yaml/S_PS_R_GIT_0030.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0030_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_githubEnterprise
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHubEnterprise.Org_test_Automation.path }}
 
 pipelines:
   - name: pipelines_S_PS_R_GIT_0030

--- a/tests/yaml/S_PS_R_GIT_0031.yml
+++ b/tests/yaml/S_PS_R_GIT_0031.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0031_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHubEnterprise.Org_test_Automation.path }}
       branches:
         include: master
       #buildOn:  # optional

--- a/tests/yaml/S_PS_R_GIT_0032.yml
+++ b/tests/yaml/S_PS_R_GIT_0032.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_R_GIT_0032
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipelines_S_PS_R_GIT_0032

--- a/tests/yaml/S_PS_UTIL_0008.yml
+++ b/tests/yaml/S_PS_UTIL_0008.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL_0008
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0008

--- a/tests/yaml/S_PS_UTIL_0009.yml
+++ b/tests/yaml/S_PS_UTIL_0009.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0009

--- a/tests/yaml/S_PS_UTIL_0015.yml
+++ b/tests/yaml/S_PS_UTIL_0015.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0015

--- a/tests/yaml/S_PS_UTIL_0021.yml
+++ b/tests/yaml/S_PS_UTIL_0021.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0021

--- a/tests/yaml/S_PS_UTIL_0023.yml
+++ b/tests/yaml/S_PS_UTIL_0023.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0023

--- a/tests/yaml/S_PS_UTIL_0027.yml
+++ b/tests/yaml/S_PS_UTIL_0027.yml
@@ -1,11 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
-      branches:
-        include: master
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0027

--- a/tests/yaml/S_PS_UTIL_0028.yml
+++ b/tests/yaml/S_PS_UTIL_0028.yml
@@ -1,11 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
-      branches:
-        include: master
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0028

--- a/tests/yaml/S_PS_UTIL_0029.yml
+++ b/tests/yaml/S_PS_UTIL_0029.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0029

--- a/tests/yaml/S_PS_UTIL_0030.yml
+++ b/tests/yaml/S_PS_UTIL_0030.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0030

--- a/tests/yaml/S_PS_UTIL_0031.yml
+++ b/tests/yaml/S_PS_UTIL_0031.yml
@@ -1,9 +1,13 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
+
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0031

--- a/tests/yaml/S_PS_UTIL_0032.yml
+++ b/tests/yaml/S_PS_UTIL_0032.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0032

--- a/tests/yaml/S_PS_UTIL_0033.yml
+++ b/tests/yaml/S_PS_UTIL_0033.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0033

--- a/tests/yaml/S_PS_UTIL_0034.yml
+++ b/tests/yaml/S_PS_UTIL_0034.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0034

--- a/tests/yaml/S_PS_UTIL_0035.yml
+++ b/tests/yaml/S_PS_UTIL_0035.yml
@@ -1,9 +1,13 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
+
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0035

--- a/tests/yaml/S_PS_UTIL_0036.yml
+++ b/tests/yaml/S_PS_UTIL_0036.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0036

--- a/tests/yaml/S_PS_UTIL_0037.yml
+++ b/tests/yaml/S_PS_UTIL_0037.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0037

--- a/tests/yaml/S_PS_UTIL_0038.yml
+++ b/tests/yaml/S_PS_UTIL_0038.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0038

--- a/tests/yaml/S_PS_UTIL_0039.yml
+++ b/tests/yaml/S_PS_UTIL_0039.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0039

--- a/tests/yaml/S_PS_UTIL_0040.yml
+++ b/tests/yaml/S_PS_UTIL_0040.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0040

--- a/tests/yaml/S_PS_UTIL_0041.yml
+++ b/tests/yaml/S_PS_UTIL_0041.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0041

--- a/tests/yaml/S_PS_UTIL_0042.yml
+++ b/tests/yaml/S_PS_UTIL_0042.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0042

--- a/tests/yaml/S_PS_UTIL_0043.yml
+++ b/tests/yaml/S_PS_UTIL_0043.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0043

--- a/tests/yaml/S_PS_UTIL_0044.yml
+++ b/tests/yaml/S_PS_UTIL_0044.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0044

--- a/tests/yaml/S_PS_UTIL_0045.yml
+++ b/tests/yaml/S_PS_UTIL_0045.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0045

--- a/tests/yaml/S_PS_UTIL_0046.yml
+++ b/tests/yaml/S_PS_UTIL_0046.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0046

--- a/tests/yaml/S_PS_UTIL_0047.yml
+++ b/tests/yaml/S_PS_UTIL_0047.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0047

--- a/tests/yaml/S_PS_UTIL_0048.yml
+++ b/tests/yaml/S_PS_UTIL_0048.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0048

--- a/tests/yaml/S_PS_UTIL_0049.yml
+++ b/tests/yaml/S_PS_UTIL_0049.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0049

--- a/tests/yaml/S_PS_UTIL_0050.yml
+++ b/tests/yaml/S_PS_UTIL_0050.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0050

--- a/tests/yaml/S_PS_UTIL_0051.yml
+++ b/tests/yaml/S_PS_UTIL_0051.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0051

--- a/tests/yaml/S_PS_UTIL_0052.yml
+++ b/tests/yaml/S_PS_UTIL_0052.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0052

--- a/tests/yaml/S_PS_UTIL_0053.yml
+++ b/tests/yaml/S_PS_UTIL_0053.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0053

--- a/tests/yaml/S_PS_UTIL_0054.yml
+++ b/tests/yaml/S_PS_UTIL_0054.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0054

--- a/tests/yaml/S_PS_UTIL_0055.yml
+++ b/tests/yaml/S_PS_UTIL_0055.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0055

--- a/tests/yaml/S_PS_UTIL_0056.yml
+++ b/tests/yaml/S_PS_UTIL_0056.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0056

--- a/tests/yaml/S_PS_UTIL_0057.yml
+++ b/tests/yaml/S_PS_UTIL_0057.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0057

--- a/tests/yaml/S_PS_UTIL_0058.yml
+++ b/tests/yaml/S_PS_UTIL_0058.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0058

--- a/tests/yaml/S_PS_UTIL_0059.yml
+++ b/tests/yaml/S_PS_UTIL_0059.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0059

--- a/tests/yaml/S_PS_UTIL_0060.yml
+++ b/tests/yaml/S_PS_UTIL_0060.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0060

--- a/tests/yaml/S_PS_UTIL_0061.yml
+++ b/tests/yaml/S_PS_UTIL_0061.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0061

--- a/tests/yaml/S_PS_UTIL_0062.yml
+++ b/tests/yaml/S_PS_UTIL_0062.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0062

--- a/tests/yaml/S_PS_UTIL_0063.yml
+++ b/tests/yaml/S_PS_UTIL_0063.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0063

--- a/tests/yaml/S_PS_UTIL_0064.yml
+++ b/tests/yaml/S_PS_UTIL_0064.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0064

--- a/tests/yaml/S_PS_UTIL_0065.yml
+++ b/tests/yaml/S_PS_UTIL_0065.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0065

--- a/tests/yaml/S_PS_UTIL_0066.yml
+++ b/tests/yaml/S_PS_UTIL_0066.yml
@@ -1,11 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
-      branches:
-        include: master
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0066

--- a/tests/yaml/S_PS_UTIL_0067.yml
+++ b/tests/yaml/S_PS_UTIL_0067.yml
@@ -1,11 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
-      branches:
-        include: master
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0067

--- a/tests/yaml/S_PS_UTIL_0068.yml
+++ b/tests/yaml/S_PS_UTIL_0068.yml
@@ -1,11 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
-      branches:
-        include: master
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0068

--- a/tests/yaml/S_PS_UTIL_0069.yml
+++ b/tests/yaml/S_PS_UTIL_0069.yml
@@ -1,11 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
-      branches:
-        include: master
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0069

--- a/tests/yaml/S_PS_UTIL_0070.yml
+++ b/tests/yaml/S_PS_UTIL_0070.yml
@@ -1,11 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
-      branches:
-        include: master
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0070

--- a/tests/yaml/S_PS_UTIL_0071.yml
+++ b/tests/yaml/S_PS_UTIL_0071.yml
@@ -1,11 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
-      branches:
-        include: master
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0071

--- a/tests/yaml/S_PS_UTIL_0072.yml
+++ b/tests/yaml/S_PS_UTIL_0072.yml
@@ -1,11 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
-      branches:
-        include: master
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0072
@@ -21,7 +22,7 @@ pipelines:
           onExecute:
             - fsutil file createnew output.dat 1073741824 #1GB
             - add_run_files output.dat my_state
-            
+
       - name: S_PS_UTIL_0072_2
         type: PowerShell
         configuration:

--- a/tests/yaml/S_PS_UTIL_0077.yml
+++ b/tests/yaml/S_PS_UTIL_0077.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0077

--- a/tests/yaml/S_PS_UTIL_0078.yml
+++ b/tests/yaml/S_PS_UTIL_0078.yml
@@ -1,10 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0078

--- a/tests/yaml/S_PS_UTIL_0079.yml
+++ b/tests/yaml/S_PS_UTIL_0079.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0079

--- a/tests/yaml/S_PS_UTIL_0080.yml
+++ b/tests/yaml/S_PS_UTIL_0080.yml
@@ -1,9 +1,12 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
 resources:
   - name: S_PS_UTIL
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
-      path: jfbetapipeorg/Org_test_Automation
+      path: {{ .Values.GitHub.Org_test_Automation.path }}
 
 pipelines:
   - name: pipeline_S_PS_UTIL_0080


### PR DESCRIPTION
Updates all the GitRepo inputs to use templated paths to allow the repositories used to be temporarily changed more easily.  The YMLs for tests that are not currently skipped have been confirmed to still work.