### PR TITLE
Updates S_PS_Generic_0063 to omit port from URL if 80.

### DIFF
--- a/tests/yaml/S_PS_Generic_0063.yml
+++ b/tests/yaml/S_PS_Generic_0063.yml
@@ -13,7 +13,11 @@ pipelines:
               $artifactory_url = [System.Uri]$int_s_artifactory_url
               $artifactory_registry_host = $artifactory_url.Host
               $artifactory_registry_port = $artifactory_url.Port
-              add_run_variables artifactory_registry_url="${artifactory_registry_host}:${artifactory_registry_port}"
+              if ($artifactory_registry_port -eq 80) {
+                add_run_variables artifactory_registry_url="${artifactory_registry_host}"
+              } else {
+                add_run_variables artifactory_registry_url="${artifactory_registry_host}:${artifactory_registry_port}"
+              }
               add_run_variables imageName="${artifactory_registry_url}/test-automation-docker-local/s_ps_generic_0063"
               add_run_variables imageTag="${run_id}"
               Set-Content -Path Dockerfile -Value "FROM releases-docker.jfrog.io/jfrog/pipelines-w19dotnetcore:3.1"


### PR DESCRIPTION
Leaves the port out of the image name if it is 80 so that insecure registries configured without the port will work in those cases.  If the port is not 80, insecure registries must contain the port.