### PR TITLE
PIPE-6887 - Shorten names.

### DIFF
--- a/tests/yaml/S_PS_GoPublishModule_6887_0001.yml
+++ b/tests/yaml/S_PS_GoPublishModule_6887_0001.yml
@@ -2,7 +2,7 @@ template: true
 valuesFilePath: ../values/gitRepoValues.yml
 
 resources:
-  - name: S_PS_GoPublishModule_6887_0001_GitRepo
+  - name: S_PS_GoPM_6887_0001_GitRepo
     type: GitRepo
     configuration:
       gitProvider: s_gitHub
@@ -11,24 +11,21 @@ resources:
         include: {{gitBranch}}
 
 pipelines:
-  - name: pipeline_S_PS_GoPublishModule_6887_0001
+  - name: pipeline_S_PS_GoPM_6887_0001
     configuration:
       nodePool: win_2019
     steps:
       - name: S_PS_GoPublishModule_6887_0001_1
         type: GoPublishModule
         configuration:
-          environmentVariables:
-            include_self: "false"
           inputResources:
-            - name: S_PS_GoPublishModule_6887_0001_GitRepo
+            - name: S_PS_GoPM_6887_0001_GitRepo
           integrations:
             - name: s_artifactory
           version: "v0.9.${run_number}"
           resolverRepo: "test-automation-go-virtual"
           targetRepository: "test-automation-go-local"
           sourceLocation: "tests/Go"
-          self: ${include_self}
       - name: S_PS_GoPublishModule_6887_0001_2
         type: PowerShell
         configuration:


### PR DESCRIPTION
Shortens the pipeline and resource names to shorten the file paths.  And I think `self` wasn't meant to be in this test case.