### PR TITLE
PIPE-9887 - Add missing PowerShell NpmPublish test.

### DIFF
--- a/tests/yaml/S_PS_NpmPublish_7122_001.yml
+++ b/tests/yaml/S_PS_NpmPublish_7122_001.yml
@@ -1,0 +1,66 @@
+template: true
+valuesFilePath: ../values/gitRepoValues.yml
+
+resources:
+  - name: S_PS_NpmP_7122_001_GitRepo
+    type: GitRepo
+    configuration:
+      gitProvider: s_gitHub
+      path: {{ .Values.GitHub.Org_test_Automation_PowerShell.path }}
+      branches:
+        include: {{gitBranch}}
+  - name: S_PS_NpmPublish_7122_001_buildInfo
+    type: BuildInfo
+    configuration:
+      sourceArtifactory: s_artifactory
+
+pipelines:
+  - name: S_PS_NpmPublish_7122_001
+    configuration:
+      jfrogCliVersion: 2
+      nodePool: win_2019
+    steps:
+      - name: S_PS_NpmPublish_7122_001_1
+        type: NpmBuild
+        configuration:
+          environmentVariables:
+            JFROG_CLI_BUILD_NUMBER: ${run_id}
+          affinityGroup: bldGroup
+          sourceLocation: "tests/npm"
+          resolverRepo: "test-automation-npm-remote"
+          integrations:
+            - name: s_artifactory
+          inputResources:
+            - name: S_PS_NpmP_7122_001_GitRepo
+        execution:
+          onStart:
+          - replace_envs ${res_S_PS_NpmP_7122_001_GitRepo_resourcePath}\tests\npm\package.json
+      - name: S_PS_NpmPublish_7122_001_2
+        type: NpmPublish
+        configuration:
+          affinityGroup: bldGroup
+          autoPublishBuildInfo: true
+          deployerRepo: "test-automation-npm-local"
+          forceXrayScan: true
+          integrations:
+            - name: s_artifactory
+          inputSteps:
+            - name: S_PS_NpmPublish_7122_001_1
+          outputResources:
+            - name: S_PS_NpmPublish_7122_001_buildInfo
+        execution:
+          onStart:
+            - Get-Command jfrog | Select-Object -ExpandProperty Definition
+            - add_run_variables buildName=${JFROG_CLI_BUILD_NAME} buildNumber=${JFROG_CLI_BUILD_NUMBER}
+      - name: S_PS_NpmPublish_7122_001_3
+        type: PowerShell
+        configuration:
+          inputResources:
+            - name: S_PS_NpmPublish_7122_001_buildInfo
+          inputSteps:
+            - name: S_PS_NpmPublish_7122_001_2
+          integrations:
+            - name: s_artifactory
+        execution:
+          onExecute:
+            - jfrog rt curl -XDELETE "/api/build/${res_S_PS_NpmPublish_7122_001_buildInfo_buildName}?buildNumbers=${res_S_PS_NpmPublish_7122_001_buildInfo_buildNumber}&artifacts=1"


### PR DESCRIPTION
Add back a copy of S_PS_NpmPublish_6679_001, with the number of the test case that still uses it.